### PR TITLE
Custom colors, custom arrow image, and date format fix

### DIFF
--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.h
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.h
@@ -36,6 +36,7 @@ typedef enum{
 
 @interface EGORefreshTableHeaderView : UIView {
 	
+	UIColor *borderColor;
 	UILabel *lastUpdatedLabel;
 	UILabel *statusLabel;
 	CALayer *arrowImage;
@@ -49,5 +50,9 @@ typedef enum{
 
 - (void)setCurrentDate;
 - (void)setState:(EGOPullRefreshState)aState;
+- (void)setArrowImageName:(NSString*)imageName;
+- (void)setBorderColor:(UIColor*)color;
+- (void)setTextColor:(UIColor*)color;
+- (void)setTextShadowColor:(UIColor*)color;
 
 @end

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
@@ -41,6 +41,8 @@
 		
 		self.autoresizingMask = UIViewAutoresizingFlexibleWidth;
         
+		borderColor = [BORDER_COLOR retain];
+
 		lastUpdatedLabel = [[UILabel alloc] initWithFrame:CGRectMake(0.0f, frame.size.height - 30.0f, self.frame.size.width, 20.0f)];
 		lastUpdatedLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
 		lastUpdatedLabel.font = [UIFont systemFontOfSize:12.0f];
@@ -73,7 +75,7 @@
 		arrowImage = [[CALayer alloc] init];
 		arrowImage.frame = CGRectMake(25.0f, frame.size.height - 65.0f, 30.0f, 55.0f);
 		arrowImage.contentsGravity = kCAGravityResizeAspect;
-		arrowImage.contents = (id)[UIImage imageNamed:@"blueArrow.png"].CGImage;
+		[self setArrowImageName:@"blueArrow.png"];
 		[[self layer] addSublayer:arrowImage];
 		[arrowImage release];
 		
@@ -90,7 +92,7 @@
 - (void)drawRect:(CGRect)rect{
 	CGContextRef context = UIGraphicsGetCurrentContext();
 	CGContextDrawPath(context,  kCGPathFillStroke);
-	[BORDER_COLOR setStroke];
+	[borderColor setStroke];
 	CGContextBeginPath(context);
 	CGContextMoveToPoint(context, 0.0f, self.bounds.size.height - 1);
 	CGContextAddLineToPoint(context, self.bounds.size.width, self.bounds.size.height - 1);
@@ -101,7 +103,7 @@
 	NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
 	[formatter setAMSymbol:@"AM"];
 	[formatter setPMSymbol:@"PM"];
-	[formatter setDateFormat:@"MM/dd/yyyy hh:mm:a"];
+	[formatter setDateFormat:@"MM/dd/yyyy hh:mm a"];
 	lastUpdatedLabel.text = [NSString stringWithFormat:@"Last Updated: %@", [formatter stringFromDate:[NSDate date]]];
 	[[NSUserDefaults standardUserDefaults] setObject:lastUpdatedLabel.text forKey:@"EGORefreshTableView_LastRefresh"];
 	[[NSUserDefaults standardUserDefaults] synchronize];
@@ -156,6 +158,9 @@
 }
 
 - (void)dealloc {
+	[borderColor release];
+
+	borderColor = nil;
 	activityView = nil;
 	statusLabel = nil;
 	arrowImage = nil;
@@ -163,5 +168,23 @@
     [super dealloc];
 }
 
+- (void)setArrowImageName:(NSString*)imageName {
+	arrowImage.contents = (id)[UIImage imageNamed:imageName].CGImage;
+}
+
+- (void)setBorderColor:(UIColor*)color {
+	[borderColor release];
+	borderColor = [color retain];
+}
+
+- (void)setTextColor:(UIColor*)color {
+	lastUpdatedLabel.textColor = color;
+	statusLabel.textColor = color;
+}
+
+- (void)setTextShadowColor:(UIColor*)color {
+	lastUpdatedLabel.shadowColor = color;
+	statusLabel.shadowColor = color;
+}
 
 @end


### PR DESCRIPTION
With minimal extra code, this allows the programmer to change the text and border colors of the header and use his/her own arrow image.

It also fixes what seems like a bug in the current EGOTableViewPullRefresh master, where the date has a colon between the minutes section and the AM/PM section (so my fix would change "11:13:PM" to "11:13 PM").
