### PR TITLE
extending functionality to handle footer also

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.xcworkspace
+xcuserdata
+build

--- a/Demo/TableViewPull/Classes/Controller/RootViewController/RootViewController.m
+++ b/Demo/TableViewPull/Classes/Controller/RootViewController/RootViewController.m
@@ -47,7 +47,7 @@
     [super viewDidLoad];
     
     _sampleData = [[NSMutableArray alloc] initWithObjects:@"1",@"2",@"3",@"4",@"5",@"6",@"7",@"8",@"9",@"10",nil];
-
+    [self.tableView reloadData];
 	if (refreshHeaderView == nil) {
 		refreshHeaderView = [[EGORefreshTableHeaderView alloc] initWithFrame:CGRectMake(0.0f, 0.0f - self.tableView.bounds.size.height, 320.0f, self.tableView.bounds.size.height)];
 		refreshHeaderView.backgroundColor = [UIColor colorWithRed:226.0/255.0 green:231.0/255.0 blue:237.0/255.0 alpha:1.0];
@@ -257,8 +257,9 @@
 }
 
 - (float)tableViewHeight {
-    // calculate height of table view (modify for multiple sections)
-    return self.tableView.rowHeight * [self tableView:self.tableView numberOfRowsInSection:0];
+	
+    // return height of table view
+    return [self.tableView contentSize].height;
 }
 
 - (void)repositionRefreshHeaderView {

--- a/Demo/TableViewPull/Classes/View/RefreshTableHeaderView/EGORefreshTableFooterView.h
+++ b/Demo/TableViewPull/Classes/View/RefreshTableHeaderView/EGORefreshTableFooterView.h
@@ -1,9 +1,9 @@
 //
-//  RootViewController.h
-//  TableViewPull
+//  EGORefreshTableFooterView.h
+//  Demo
 //
-//  Created by Devin Doty on 10/16/09October16.
-//  Copyright enormego 2009. All rights reserved.
+//  Created by Zbigniew Kominek on 3/10/11.
+//  Copyright 2011 Zbigniew Kominek. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -24,23 +24,12 @@
 //  THE SOFTWARE.
 //
 
-@class EGORefreshTableHeaderView;
-@class EGORefreshTableFooterView;
-@interface RootViewController : UITableViewController  <UITableViewDelegate, UITableViewDataSource>{
-	EGORefreshTableHeaderView *refreshHeaderView;
-    EGORefreshTableFooterView *refreshFooterView;
-	
-	//  Reloading should really be your tableviews model class
-	//  Putting it here for demo purposes 
-	BOOL _reloadingHeader;
-    BOOL _reloadingFooter;
-    
-    //  Sample data - do not include in your project
-    NSMutableArray *_sampleData;
+#import <Foundation/Foundation.h>
+#import "EGORefreshTableHeaderView.h"
+
+
+@interface EGORefreshTableFooterView : EGORefreshTableHeaderView {
+
 }
 
-@property(assign,getter=isReloading) BOOL reloading;
-
-- (void)reloadTableViewDataSource;
-- (void)doneLoadingTableViewData;
 @end

--- a/Demo/TableViewPull/Classes/View/RefreshTableHeaderView/EGORefreshTableFooterView.m
+++ b/Demo/TableViewPull/Classes/View/RefreshTableHeaderView/EGORefreshTableFooterView.m
@@ -1,0 +1,48 @@
+//
+//  EGORefreshTableFooterView.m
+//  Demo
+//
+//  Created by Zbigniew Kominek on 3/10/11.
+//  Copyright 2011 Zbigniew Kominek. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import "EGORefreshTableFooterView.h"
+
+
+@implementation EGORefreshTableFooterView
+
+- (void)setup:(CGRect)frame {
+    _lastUpdatedLabelFrame = CGRectMake(0.0f, 10.0f, self.frame.size.width, 20.0f);
+    _statusLabelFrame      = CGRectMake(0.0f, 28.0f, self.frame.size.width, 20.0f);
+    _arrowImageFrame       = CGRectMake(25.0f, 10.0f, 30.0f, 55.0f);
+    _activityViewFrame     = CGRectMake(25.0f, 18.0f, 20.0f, 20.0f);
+    
+    _arrowPullingTransform = CATransform3DMakeRotation((M_PI / 180.0f) * -360.0f, 0.0f, 0.0f, 1.0f);
+    _arrowNormalTransform  = CATransform3DMakeRotation((M_PI / 180.0f) *  180.0f, 0.0f, 0.0f, 1.0f);
+    
+    _releaseLabelText = NSLocalizedString(@"Release to refresh...", @"Release to refresh status");
+    _pullingLabelText = NSLocalizedString(@"Pull up to refresh...", @"Pull down to refresh status");
+    _loadingLabelText = NSLocalizedString(@"Loading...", @"Loading Status");
+    
+    _userDefaultsKey = @"EGORefreshTableFooterView_LastRefresh";
+}
+
+@end

--- a/Demo/TableViewPull/Classes/View/RefreshTableHeaderView/EGORefreshTableHeaderView.h
+++ b/Demo/TableViewPull/Classes/View/RefreshTableHeaderView/EGORefreshTableHeaderView.h
@@ -43,11 +43,29 @@ typedef enum{
 	
 	EGOPullRefreshState _state;
 
+@protected
+    CGRect _lastUpdatedLabelFrame;
+    CGRect _statusLabelFrame;
+    CGRect _arrowImageFrame;
+    CGRect _activityViewFrame;
+    
+    CATransform3D _arrowPullingTransform;
+    CATransform3D _arrowNormalTransform;
+    
+    NSString *_releaseLabelText;
+    NSString *_pullingLabelText;
+    NSString *_loadingLabelText;
+    
+    NSString *_userDefaultsKey;
 }
 
 @property(nonatomic,assign) EGOPullRefreshState state;
+@property(nonatomic,retain) NSString *releaseLabelText;
+@property(nonatomic,retain) NSString *pullingLabelText;
+@property(nonatomic,retain) NSString *loadingLabelText;
 
 - (void)setCurrentDate;
 - (void)setState:(EGOPullRefreshState)aState;
+- (void)setup:(CGRect)frame;
 
 @end

--- a/Demo/TableViewPull/Classes/View/RefreshTableHeaderView/EGORefreshTableHeaderView.m
+++ b/Demo/TableViewPull/Classes/View/RefreshTableHeaderView/EGORefreshTableHeaderView.m
@@ -106,7 +106,7 @@
 	NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
 	[formatter setAMSymbol:@"AM"];
 	[formatter setPMSymbol:@"PM"];
-	[formatter setDateFormat:@"MM/dd/yyyy hh:mm:a"];
+	[formatter setDateFormat:@"MM/dd/yyyy hh:mm a"];
 	_lastUpdatedLabel.text = [NSString stringWithFormat:@"Last Updated: %@", [formatter stringFromDate:[NSDate date]]];
 	[[NSUserDefaults standardUserDefaults] setObject:_lastUpdatedLabel.text forKey:_userDefaultsKey];
 	[[NSUserDefaults standardUserDefaults] synchronize];

--- a/Demo/TableViewPull/TableViewPull.xcodeproj/project.pbxproj
+++ b/Demo/TableViewPull/TableViewPull.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
+		267789F513296258002564C5 /* EGORefreshTableFooterView.m in Sources */ = {isa = PBXBuildFile; fileRef = 267789F413296258002564C5 /* EGORefreshTableFooterView.m */; };
 		2892E4100DC94CBA00A64D0F /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2892E40F0DC94CBA00A64D0F /* CoreGraphics.framework */; };
 		28AD73600D9D9599002E5188 /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28AD735F0D9D9599002E5188 /* MainWindow.xib */; };
 		28F335F11007B36200424DE2 /* RootViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28F335F01007B36200424DE2 /* RootViewController.xib */; };
@@ -31,6 +32,8 @@
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D6058910D05DD3D006BFB54 /* TableViewPull.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TableViewPull.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1DF5F4DF0D08C38300B7A737 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		267789F313296258002564C5 /* EGORefreshTableFooterView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EGORefreshTableFooterView.h; sourceTree = "<group>"; };
+		267789F413296258002564C5 /* EGORefreshTableFooterView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EGORefreshTableFooterView.m; sourceTree = "<group>"; };
 		2892E40F0DC94CBA00A64D0F /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		28AD735F0D9D9599002E5188 /* MainWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MainWindow.xib; sourceTree = "<group>"; };
 		28F335F01007B36200424DE2 /* RootViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RootViewController.xib; sourceTree = "<group>"; };
@@ -167,6 +170,8 @@
 			children = (
 				3A3D909C11188064002B6585 /* EGORefreshTableHeaderView.h */,
 				3A3D909D11188064002B6585 /* EGORefreshTableHeaderView.m */,
+				267789F313296258002564C5 /* EGORefreshTableFooterView.h */,
+				267789F413296258002564C5 /* EGORefreshTableFooterView.m */,
 			);
 			path = RefreshTableHeaderView;
 			sourceTree = "<group>";
@@ -254,6 +259,7 @@
 				3A3D909E11188064002B6585 /* EGORefreshTableHeaderView.m in Sources */,
 				3A3D90A8111881DE002B6585 /* RootViewController.m in Sources */,
 				3A3D910311188495002B6585 /* main.m in Sources */,
+				267789F513296258002564C5 /* EGORefreshTableFooterView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -272,6 +278,7 @@
 				INFOPLIST_FILE = "Resources/TableViewPull-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 3.0;
 				PRODUCT_NAME = TableViewPull;
+				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -286,6 +293,7 @@
 				INFOPLIST_FILE = "Resources/TableViewPull-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 3.0;
 				PRODUCT_NAME = TableViewPull;
+				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableFooterView.h
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableFooterView.h
@@ -1,9 +1,9 @@
 //
-//  RootViewController.h
-//  TableViewPull
+//  EGORefreshTableFooterView.h
+//  Demo
 //
-//  Created by Devin Doty on 10/16/09October16.
-//  Copyright enormego 2009. All rights reserved.
+//  Created by Zbigniew Kominek on 3/10/11.
+//  Copyright 2011 Zbigniew Kominek. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -24,23 +24,12 @@
 //  THE SOFTWARE.
 //
 
-@class EGORefreshTableHeaderView;
-@class EGORefreshTableFooterView;
-@interface RootViewController : UITableViewController  <UITableViewDelegate, UITableViewDataSource>{
-	EGORefreshTableHeaderView *refreshHeaderView;
-    EGORefreshTableFooterView *refreshFooterView;
-	
-	//  Reloading should really be your tableviews model class
-	//  Putting it here for demo purposes 
-	BOOL _reloadingHeader;
-    BOOL _reloadingFooter;
-    
-    //  Sample data - do not include in your project
-    NSMutableArray *_sampleData;
+#import <Foundation/Foundation.h>
+#import "EGORefreshTableHeaderView.h"
+
+
+@interface EGORefreshTableFooterView : EGORefreshTableHeaderView {
+
 }
 
-@property(assign,getter=isReloading) BOOL reloading;
-
-- (void)reloadTableViewDataSource;
-- (void)doneLoadingTableViewData;
 @end

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableFooterView.m
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableFooterView.m
@@ -1,0 +1,48 @@
+//
+//  EGORefreshTableFooterView.m
+//  Demo
+//
+//  Created by Zbigniew Kominek on 3/10/11.
+//  Copyright 2011 Zbigniew Kominek. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import "EGORefreshTableFooterView.h"
+
+
+@implementation EGORefreshTableFooterView
+
+- (void)setup:(CGRect)frame {
+    _lastUpdatedLabelFrame = CGRectMake(0.0f, 10.0f, self.frame.size.width, 20.0f);
+    _statusLabelFrame      = CGRectMake(0.0f, 28.0f, self.frame.size.width, 20.0f);
+    _arrowImageFrame       = CGRectMake(25.0f, 10.0f, 30.0f, 55.0f);
+    _activityViewFrame     = CGRectMake(25.0f, 18.0f, 20.0f, 20.0f);
+    
+    _arrowPullingTransform = CATransform3DMakeRotation((M_PI / 180.0f) * -360.0f, 0.0f, 0.0f, 1.0f);
+    _arrowNormalTransform  = CATransform3DMakeRotation((M_PI / 180.0f) *  180.0f, 0.0f, 0.0f, 1.0f);
+    
+    _releaseLabelText = NSLocalizedString(@"Release to refresh...", @"Release to refresh status");
+    _pullingLabelText = NSLocalizedString(@"Pull up to refresh...", @"Pull down to refresh status");
+    _loadingLabelText = NSLocalizedString(@"Loading...", @"Loading Status");
+    
+    _userDefaultsKey = @"EGORefreshTableFooterView_LastRefresh";
+}
+
+@end

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.h
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.h
@@ -36,18 +36,36 @@ typedef enum{
 
 @interface EGORefreshTableHeaderView : UIView {
 	
-	UILabel *lastUpdatedLabel;
-	UILabel *statusLabel;
-	CALayer *arrowImage;
-	UIActivityIndicatorView *activityView;
+	UILabel *_lastUpdatedLabel;
+	UILabel *_statusLabel;
+	CALayer *_arrowImage;
+	UIActivityIndicatorView *_activityView;
 	
 	EGOPullRefreshState _state;
 
+@protected
+    CGRect _lastUpdatedLabelFrame;
+    CGRect _statusLabelFrame;
+    CGRect _arrowImageFrame;
+    CGRect _activityViewFrame;
+    
+    CATransform3D _arrowPullingTransform;
+    CATransform3D _arrowNormalTransform;
+    
+    NSString *_releaseLabelText;
+    NSString *_pullingLabelText;
+    NSString *_loadingLabelText;
+    
+    NSString *_userDefaultsKey;
 }
 
 @property(nonatomic,assign) EGOPullRefreshState state;
+@property(nonatomic,retain) NSString *releaseLabelText;
+@property(nonatomic,retain) NSString *pullingLabelText;
+@property(nonatomic,retain) NSString *loadingLabelText;
 
 - (void)setCurrentDate;
 - (void)setState:(EGOPullRefreshState)aState;
+- (void)setup:(CGRect)frame;
 
 @end

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
@@ -106,7 +106,7 @@
 	NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
 	[formatter setAMSymbol:@"AM"];
 	[formatter setPMSymbol:@"PM"];
-	[formatter setDateFormat:@"MM/dd/yyyy hh:mm:a"];
+	[formatter setDateFormat:@"MM/dd/yyyy hh:mm a"];
 	_lastUpdatedLabel.text = [NSString stringWithFormat:@"Last Updated: %@", [formatter stringFromDate:[NSDate date]]];
 	[[NSUserDefaults standardUserDefaults] setObject:_lastUpdatedLabel.text forKey:_userDefaultsKey];
 	[[NSUserDefaults standardUserDefaults] synchronize];


### PR DESCRIPTION
This change makes possible to place your brilliant refresh view in footer also.

It modifies a little your base class (EGORefreshTableHeaderView) to be able to setup some values using instance method. This way it is possible for my new derived class to setup different values and make it possible to place it just after table view.

I included usage example in your demo project.

Thanks for a great idea of handling table view refresh.
