### PR TITLE
EGOStyle

### DIFF
--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.h
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.h
@@ -61,6 +61,8 @@ typedef enum {
     NSString *_objectKey;
     
     EGOStyle _style;
+    
+    UIEdgeInsets _defaultInsets;
 }
 
 @property (nonatomic, assign) id <EGORefreshTableHeaderDelegate> delegate;
@@ -73,6 +75,8 @@ typedef enum {
 @property (nonatomic, copy) NSString *objectKey;
 
 @property (assign) EGOStyle style;
+
+@property (assign) UIEdgeInsets defaultInsets;
 
 - (id)initWithFrame:(CGRect)frame style:(EGOStyle)style;
 - (id)initWithView:(UIView *)view tableView:(UITableView *)tableView;

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.h
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.h
@@ -35,6 +35,14 @@ typedef enum {
 } EGOPullRefreshState;
 
 
+typedef enum {
+    EGOStyleBlue,
+    EGOStyleBlack,
+    EGOStyleWhite,
+    EGOStyleGrey,
+} EGOStyle;
+
+
 @protocol EGORefreshTableHeaderDelegate;
 
 @interface EGORefreshTableHeaderView : UIView
@@ -51,9 +59,11 @@ typedef enum {
     UIActivityIndicatorView *_activityView;
     
     NSString *_objectKey;
+    
+    EGOStyle _style;
 }
 
-@property(nonatomic, assign) id <EGORefreshTableHeaderDelegate> delegate;
+@property (nonatomic, assign) id <EGORefreshTableHeaderDelegate> delegate;
 
 @property (nonatomic, retain) UIActivityIndicatorView *activityView;
 @property (nonatomic, retain) CALayer *arrowImage;
@@ -62,12 +72,22 @@ typedef enum {
 
 @property (nonatomic, copy) NSString *objectKey;
 
-- (id)initWithFrame:(CGRect)frame arrowImageName:(NSString *)arrow textColor:(UIColor *)textColor;
-- (id)initWithView:(UIView *)view andTableView:(UITableView *)tableView;
+@property (assign) EGOStyle style;
+
+- (id)initWithFrame:(CGRect)frame style:(EGOStyle)style;
+- (id)initWithView:(UIView *)view tableView:(UITableView *)tableView;
+- (id)initWithView:(UIView *)view tableView:(UITableView *)tableView style:(EGOStyle)style;
+
+- (id)initWithFrame:(CGRect)frame 
+     arrowImageName:(NSString *)arrow 
+          textColor:(UIColor *)textColor 
+    backgroundColor:(UIColor *)backgroundColor
+      activityStyle:(UIActivityIndicatorViewStyle)activityStyle;
 
 - (void)egoRefreshScrollViewDataSourceDidFinishedLoading:(UIScrollView *)scrollView;
 - (void)egoRefreshScrollViewDidScroll:(UIScrollView *)scrollView;
 - (void)egoRefreshScrollViewDidEndDragging:(UIScrollView *)scrollView;
+
 - (void)refreshLastUpdatedDate;
 
 @end

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.h
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.h
@@ -49,12 +49,16 @@ typedef enum {
     UILabel *_statusLabel;
     
     UIActivityIndicatorView *_activityView;
+    
+    NSString *_objectKey;
 }
 
-@property(nonatomic,assign) id <EGORefreshTableHeaderDelegate> delegate;
+@property(nonatomic, assign) id <EGORefreshTableHeaderDelegate> delegate;
 
 @property (nonatomic, retain) UILabel *lastUpdatedLabel;
 @property (nonatomic, retain) UILabel *statusLabel;
+
+@property (nonatomic, copy) NSString *objectKey;
 
 - (id)initWithFrame:(CGRect)frame arrowImageName:(NSString *)arrow textColor:(UIColor *)textColor;
 - (id)initWithView:(UIView *)view andTableView:(UITableView *)tableView;

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.h
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.h
@@ -2,7 +2,7 @@
 //  EGORefreshTableHeaderView.h
 //  Demo
 //
-//  Created by Devin Doty on 10/14/09October14.
+//  Created by Devin Doty on 10/14/09
 //  Copyright 2009 enormego. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -27,39 +27,53 @@
 #import <UIKit/UIKit.h>
 #import <QuartzCore/QuartzCore.h>
 
-typedef enum{
-	EGOOPullRefreshPulling = 0,
-	EGOOPullRefreshNormal,
-	EGOOPullRefreshLoading,	
+
+typedef enum {
+    EGOOPullRefreshPulling,
+    EGOOPullRefreshNormal,
+    EGOOPullRefreshLoading,
 } EGOPullRefreshState;
 
+
 @protocol EGORefreshTableHeaderDelegate;
-@interface EGORefreshTableHeaderView : UIView {
-	
-	id _delegate;
-	EGOPullRefreshState _state;
 
-	UILabel *_lastUpdatedLabel;
-	UILabel *_statusLabel;
-	CALayer *_arrowImage;
-	UIActivityIndicatorView *_activityView;
-	
-
+@interface EGORefreshTableHeaderView : UIView
+{
+    id _delegate;
+    
+    EGOPullRefreshState _state;
+    
+    CALayer *_arrowImage;
+    
+    UILabel *_lastUpdatedLabel;
+    UILabel *_statusLabel;
+    
+    UIActivityIndicatorView *_activityView;
 }
 
 @property(nonatomic,assign) id <EGORefreshTableHeaderDelegate> delegate;
 
-- (id)initWithFrame:(CGRect)frame arrowImageName:(NSString *)arrow textColor:(UIColor *)textColor;
+@property (nonatomic, retain) UILabel *lastUpdatedLabel;
+@property (nonatomic, retain) UILabel *statusLabel;
 
-- (void)refreshLastUpdatedDate;
+- (id)initWithFrame:(CGRect)frame arrowImageName:(NSString *)arrow textColor:(UIColor *)textColor;
+- (id)initWithView:(UIView *)view andTableView:(UITableView *)tableView;
+
+- (void)egoRefreshScrollViewDataSourceDidFinishedLoading:(UIScrollView *)scrollView;
 - (void)egoRefreshScrollViewDidScroll:(UIScrollView *)scrollView;
 - (void)egoRefreshScrollViewDidEndDragging:(UIScrollView *)scrollView;
-- (void)egoRefreshScrollViewDataSourceDidFinishedLoading:(UIScrollView *)scrollView;
+- (void)refreshLastUpdatedDate;
 
 @end
+
+
 @protocol EGORefreshTableHeaderDelegate
+
 - (void)egoRefreshTableHeaderDidTriggerRefresh:(EGORefreshTableHeaderView*)view;
 - (BOOL)egoRefreshTableHeaderDataSourceIsLoading:(EGORefreshTableHeaderView*)view;
+
 @optional
+
 - (NSDate*)egoRefreshTableHeaderDataSourceLastUpdated:(EGORefreshTableHeaderView*)view;
+
 @end

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.h
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.h
@@ -55,6 +55,8 @@ typedef enum {
 
 @property(nonatomic, assign) id <EGORefreshTableHeaderDelegate> delegate;
 
+@property (nonatomic, retain) UIActivityIndicatorView *activityView;
+@property (nonatomic, retain) CALayer *arrowImage;
 @property (nonatomic, retain) UILabel *lastUpdatedLabel;
 @property (nonatomic, retain) UILabel *statusLabel;
 

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
@@ -42,12 +42,11 @@
 
 @synthesize delegate=_delegate;
 @synthesize lastUpdatedLabel=_lastUpdatedLabel;
+@synthesize objectKey=_objectKey;
 @synthesize statusLabel=_statusLabel;
 
 - (id)initWithFrame:(CGRect)frame arrowImageName:(NSString *)arrow textColor:(UIColor *)textColor
 {
-    NSLog(@"initwframe called");
-    
     if ((self = [super initWithFrame:frame]))
     {
         self.autoresizingMask = UIViewAutoresizingFlexibleWidth;
@@ -102,9 +101,7 @@
         
         [self setState:EGOOPullRefreshNormal];
     }
-    
     return self;
-    
 }
 
 - (id)initWithFrame:(CGRect)frame
@@ -134,7 +131,18 @@
         [dateFormatter setTimeStyle:NSDateFormatterShortStyle];
         
         _lastUpdatedLabel.text = [NSString stringWithFormat:@"Last Updated: %@", [dateFormatter stringFromDate:date]];
-        [[NSUserDefaults standardUserDefaults] setObject:_lastUpdatedLabel.text forKey:@"EGORefreshTableView_LastRefresh"];
+        
+        NSString *forKey;
+        if (self.objectKey)
+        {
+            forKey = [forKey stringByAppendingFormat:@"EGORefreshTableView_LastRefresh_%@", self.objectKey];
+        }
+        else
+        {
+            forKey = @"EGORefreshTableView_LastRefresh";
+        }
+        
+        [[NSUserDefaults standardUserDefaults] setObject:_lastUpdatedLabel.text forKey:forKey];
         [[NSUserDefaults standardUserDefaults] synchronize];
     }
     else
@@ -265,6 +273,7 @@
     [_activityView release];
     [_arrowImage release];
     [_lastUpdatedLabel release];
+    [_objectKey release];
     [_statusLabel release];
     
     [super dealloc];

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
@@ -2,7 +2,7 @@
 //  EGORefreshTableHeaderView.m
 //  Demo
 //
-//  Created by Devin Doty on 10/14/09October14.
+//  Created by Devin Doty on 10/14/09
 //  Copyright 2009 enormego. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -27,237 +27,247 @@
 #import "EGORefreshTableHeaderView.h"
 
 
-#define TEXT_COLOR	 [UIColor colorWithRed:87.0/255.0 green:108.0/255.0 blue:137.0/255.0 alpha:1.0]
+#define TEXT_COLOR [UIColor colorWithRed:87.0/255.0 green:108.0/255.0 blue:137.0/255.0 alpha:1.0]
 #define FLIP_ANIMATION_DURATION 0.18f
 
 
-@interface EGORefreshTableHeaderView (Private)
+@interface EGORefreshTableHeaderView(Private)
+
 - (void)setState:(EGOPullRefreshState)aState;
+
 @end
+
 
 @implementation EGORefreshTableHeaderView
 
 @synthesize delegate=_delegate;
+@synthesize lastUpdatedLabel=_lastUpdatedLabel;
+@synthesize statusLabel=_statusLabel;
 
-
-- (id)initWithFrame:(CGRect)frame arrowImageName:(NSString *)arrow textColor:(UIColor *)textColor  {
-    if((self = [super initWithFrame:frame])) {
-		
-		self.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-		self.backgroundColor = [UIColor colorWithRed:226.0/255.0 green:231.0/255.0 blue:237.0/255.0 alpha:1.0];
-
-		UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(0.0f, frame.size.height - 30.0f, self.frame.size.width, 20.0f)];
-		label.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-		label.font = [UIFont systemFontOfSize:12.0f];
-		label.textColor = textColor;
-		label.shadowColor = [UIColor colorWithWhite:0.9f alpha:1.0f];
-		label.shadowOffset = CGSizeMake(0.0f, 1.0f);
-		label.backgroundColor = [UIColor clearColor];
-		label.textAlignment = UITextAlignmentCenter;
-		[self addSubview:label];
-		_lastUpdatedLabel=label;
-		[label release];
-		
-		label = [[UILabel alloc] initWithFrame:CGRectMake(0.0f, frame.size.height - 48.0f, self.frame.size.width, 20.0f)];
-		label.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-		label.font = [UIFont boldSystemFontOfSize:13.0f];
-		label.textColor = textColor;
-		label.shadowColor = [UIColor colorWithWhite:0.9f alpha:1.0f];
-		label.shadowOffset = CGSizeMake(0.0f, 1.0f);
-		label.backgroundColor = [UIColor clearColor];
-		label.textAlignment = UITextAlignmentCenter;
-		[self addSubview:label];
-		_statusLabel=label;
-		[label release];
-		
-		CALayer *layer = [CALayer layer];
-		layer.frame = CGRectMake(25.0f, frame.size.height - 65.0f, 30.0f, 55.0f);
-		layer.contentsGravity = kCAGravityResizeAspect;
-		layer.contents = (id)[UIImage imageNamed:arrow].CGImage;
-		
+- (id)initWithFrame:(CGRect)frame arrowImageName:(NSString *)arrow textColor:(UIColor *)textColor
+{
+    NSLog(@"initwframe called");
+    
+    if ((self = [super initWithFrame:frame]))
+    {
+        self.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+        self.backgroundColor = [UIColor colorWithRed:226.0/255.0 green:231.0/255.0 blue:237.0/255.0 alpha:1.0];
+        
+        UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(0.0f,frame.size.height - 30.0f,
+                                                                   self.frame.size.width, 20.0f)];
+        label.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+        label.font = [UIFont systemFontOfSize:12.0f];
+        label.textColor = textColor;
+        label.shadowColor = [UIColor colorWithWhite:0.9f alpha:1.0f];
+        label.shadowOffset = CGSizeMake(0.0f, 1.0f);
+        label.backgroundColor = [UIColor clearColor];
+        label.textAlignment = UITextAlignmentCenter;
+        [self addSubview:label];
+        self.lastUpdatedLabel = label;
+        [label release];
+        
+        label = [[UILabel alloc] initWithFrame:CGRectMake(0.0f, frame.size.height - 48.0f,
+                                                          self.frame.size.width, 20.0f)];
+        label.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+        label.font = [UIFont boldSystemFontOfSize:13.0f];
+        label.textColor = textColor;
+        label.shadowColor = [UIColor colorWithWhite:0.9f alpha:1.0f];
+        label.shadowOffset = CGSizeMake(0.0f, 1.0f);
+        label.backgroundColor = [UIColor clearColor];
+        label.textAlignment = UITextAlignmentCenter;
+        [self addSubview:label];
+        self.statusLabel = label;
+        [label release];
+        
+        CALayer *layer = [CALayer layer];
+        layer.frame = CGRectMake(25.0f, frame.size.height - 65.0f, 30.0f, 55.0f);
+        layer.contentsGravity = kCAGravityResizeAspect;
+        layer.contents = (id)[UIImage imageNamed:arrow].CGImage;
+        
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 40000
-		if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)]) {
-			layer.contentsScale = [[UIScreen mainScreen] scale];
-		}
+        if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)])
+        {
+            layer.contentsScale = [[UIScreen mainScreen] scale];
+        }
 #endif
-		
-		[[self layer] addSublayer:layer];
-		_arrowImage=layer;
-		
-		UIActivityIndicatorView *view = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
-		view.frame = CGRectMake(25.0f, frame.size.height - 38.0f, 20.0f, 20.0f);
-		[self addSubview:view];
-		_activityView = view;
-		[view release];
-		
-		
-		[self setState:EGOOPullRefreshNormal];
-		
+        
+        [[self layer] addSublayer:layer];
+        _arrowImage=layer;
+        
+        UIActivityIndicatorView *view = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+        view.frame = CGRectMake(25.0f, frame.size.height - 38.0f, 20.0f, 20.0f);
+        [self addSubview:view];
+        _activityView = view;
+        [view release];
+        
+        [self setState:EGOOPullRefreshNormal];
     }
-	
+    
     return self;
-	
+    
 }
 
-- (id)initWithFrame:(CGRect)frame  {
-  return [self initWithFrame:frame arrowImageName:@"blueArrow.png" textColor:TEXT_COLOR];
+- (id)initWithFrame:(CGRect)frame
+{
+    return [self initWithFrame:frame arrowImageName:@"blueArrow.png" textColor:TEXT_COLOR];
 }
 
-#pragma mark -
-#pragma mark Setters
-
-- (void)refreshLastUpdatedDate {
-	
-	if ([_delegate respondsToSelector:@selector(egoRefreshTableHeaderDataSourceLastUpdated:)]) {
-		
-		NSDate *date = [_delegate egoRefreshTableHeaderDataSourceLastUpdated:self];
-		
-		[NSDateFormatter setDefaultFormatterBehavior:NSDateFormatterBehaviorDefault];
-		NSDateFormatter *dateFormatter = [[[NSDateFormatter alloc] init] autorelease];
-		[dateFormatter setDateStyle:NSDateFormatterShortStyle];
-		[dateFormatter setTimeStyle:NSDateFormatterShortStyle];
-
-		_lastUpdatedLabel.text = [NSString stringWithFormat:@"Last Updated: %@", [dateFormatter stringFromDate:date]];
-		[[NSUserDefaults standardUserDefaults] setObject:_lastUpdatedLabel.text forKey:@"EGORefreshTableView_LastRefresh"];
-		[[NSUserDefaults standardUserDefaults] synchronize];
-		
-	} else {
-		
-		_lastUpdatedLabel.text = nil;
-		
-	}
-
-}
-
-- (void)setState:(EGOPullRefreshState)aState{
-	
-	switch (aState) {
-		case EGOOPullRefreshPulling:
-			
-			_statusLabel.text = NSLocalizedString(@"Release to refresh...", @"Release to refresh status");
-			[CATransaction begin];
-			[CATransaction setAnimationDuration:FLIP_ANIMATION_DURATION];
-			_arrowImage.transform = CATransform3DMakeRotation((M_PI / 180.0) * 180.0f, 0.0f, 0.0f, 1.0f);
-			[CATransaction commit];
-			
-			break;
-		case EGOOPullRefreshNormal:
-			
-			if (_state == EGOOPullRefreshPulling) {
-				[CATransaction begin];
-				[CATransaction setAnimationDuration:FLIP_ANIMATION_DURATION];
-				_arrowImage.transform = CATransform3DIdentity;
-				[CATransaction commit];
-			}
-			
-			_statusLabel.text = NSLocalizedString(@"Pull down to refresh...", @"Pull down to refresh status");
-			[_activityView stopAnimating];
-			[CATransaction begin];
-			[CATransaction setValue:(id)kCFBooleanTrue forKey:kCATransactionDisableActions]; 
-			_arrowImage.hidden = NO;
-			_arrowImage.transform = CATransform3DIdentity;
-			[CATransaction commit];
-			
-			[self refreshLastUpdatedDate];
-			
-			break;
-		case EGOOPullRefreshLoading:
-			
-			_statusLabel.text = NSLocalizedString(@"Loading...", @"Loading Status");
-			[_activityView startAnimating];
-			[CATransaction begin];
-			[CATransaction setValue:(id)kCFBooleanTrue forKey:kCATransactionDisableActions]; 
-			_arrowImage.hidden = YES;
-			[CATransaction commit];
-			
-			break;
-		default:
-			break;
-	}
-	
-	_state = aState;
+- (id)initWithView:(UIView *)view andTableView:(UITableView *)tableView
+{
+    CGRect defaultFrame = CGRectMake(0.0f, 0.0f - tableView.bounds.size.height,
+                                     view.frame.size.width, tableView.bounds.size.height);
+    return [self initWithFrame:defaultFrame];
 }
 
 
-#pragma mark -
-#pragma mark ScrollView Methods
+#pragma mark - Setters
 
-- (void)egoRefreshScrollViewDidScroll:(UIScrollView *)scrollView {	
-	
-	if (_state == EGOOPullRefreshLoading) {
-		
-		CGFloat offset = MAX(scrollView.contentOffset.y * -1, 0);
-		offset = MIN(offset, 60);
-		scrollView.contentInset = UIEdgeInsetsMake(offset, 0.0f, 0.0f, 0.0f);
-		
-	} else if (scrollView.isDragging) {
-		
-		BOOL _loading = NO;
-		if ([_delegate respondsToSelector:@selector(egoRefreshTableHeaderDataSourceIsLoading:)]) {
-			_loading = [_delegate egoRefreshTableHeaderDataSourceIsLoading:self];
-		}
-		
-		if (_state == EGOOPullRefreshPulling && scrollView.contentOffset.y > -65.0f && scrollView.contentOffset.y < 0.0f && !_loading) {
-			[self setState:EGOOPullRefreshNormal];
-		} else if (_state == EGOOPullRefreshNormal && scrollView.contentOffset.y < -65.0f && !_loading) {
-			[self setState:EGOOPullRefreshPulling];
-		}
-		
-		if (scrollView.contentInset.top != 0) {
-			scrollView.contentInset = UIEdgeInsetsZero;
-		}
-		
-	}
-	
+- (void)refreshLastUpdatedDate
+{
+    if ([_delegate respondsToSelector:@selector(egoRefreshTableHeaderDataSourceLastUpdated:)])
+    {
+        NSDate *date = [_delegate egoRefreshTableHeaderDataSourceLastUpdated:self];
+        
+        [NSDateFormatter setDefaultFormatterBehavior:NSDateFormatterBehaviorDefault];
+        NSDateFormatter *dateFormatter = [[[NSDateFormatter alloc] init] autorelease];
+        [dateFormatter setDateStyle:NSDateFormatterShortStyle];
+        [dateFormatter setTimeStyle:NSDateFormatterShortStyle];
+        
+        _lastUpdatedLabel.text = [NSString stringWithFormat:@"Last Updated: %@", [dateFormatter stringFromDate:date]];
+        [[NSUserDefaults standardUserDefaults] setObject:_lastUpdatedLabel.text forKey:@"EGORefreshTableView_LastRefresh"];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+    }
+    else
+    {
+        _lastUpdatedLabel.text = nil;
+    }
 }
 
-- (void)egoRefreshScrollViewDidEndDragging:(UIScrollView *)scrollView {
-	
-	BOOL _loading = NO;
-	if ([_delegate respondsToSelector:@selector(egoRefreshTableHeaderDataSourceIsLoading:)]) {
-		_loading = [_delegate egoRefreshTableHeaderDataSourceIsLoading:self];
-	}
-	
-	if (scrollView.contentOffset.y <= - 65.0f && !_loading) {
-		
-		if ([_delegate respondsToSelector:@selector(egoRefreshTableHeaderDidTriggerRefresh:)]) {
-			[_delegate egoRefreshTableHeaderDidTriggerRefresh:self];
-		}
-		
-		[self setState:EGOOPullRefreshLoading];
-		[UIView beginAnimations:nil context:NULL];
-		[UIView setAnimationDuration:0.2];
-		scrollView.contentInset = UIEdgeInsetsMake(60.0f, 0.0f, 0.0f, 0.0f);
-		[UIView commitAnimations];
-		
-	}
-	
+- (void)setState:(EGOPullRefreshState)aState
+{
+    switch (aState)
+    {
+        case EGOOPullRefreshPulling:
+            _statusLabel.text = NSLocalizedString(@"Release to refresh...", @"Release to refresh status");
+            [CATransaction begin];
+            [CATransaction setAnimationDuration:FLIP_ANIMATION_DURATION];
+            _arrowImage.transform = CATransform3DMakeRotation((M_PI / 180.0) * 180.0f, 0.0f, 0.0f, 1.0f);
+            [CATransaction commit];
+            break;
+            
+        case EGOOPullRefreshNormal:
+            if (_state == EGOOPullRefreshPulling)
+            {
+                [CATransaction begin];
+                [CATransaction setAnimationDuration:FLIP_ANIMATION_DURATION];
+                _arrowImage.transform = CATransform3DIdentity;
+                [CATransaction commit];
+            }
+            _statusLabel.text = NSLocalizedString(@"Pull down to refresh...", @"Pull down to refresh status");
+            [_activityView stopAnimating];
+            [CATransaction begin];
+            [CATransaction setValue:(id)kCFBooleanTrue forKey:kCATransactionDisableActions];
+            _arrowImage.hidden = NO;
+            _arrowImage.transform = CATransform3DIdentity;
+            [CATransaction commit];
+            [self refreshLastUpdatedDate];
+            break;
+            
+        case EGOOPullRefreshLoading:
+            _statusLabel.text = NSLocalizedString(@"Loading...", @"Loading Status");
+            [_activityView startAnimating];
+            [CATransaction begin];
+            [CATransaction setValue:(id)kCFBooleanTrue forKey:kCATransactionDisableActions];
+            _arrowImage.hidden = YES;
+            [CATransaction commit];
+            break;
+    }
+    
+    _state = aState;
 }
 
-- (void)egoRefreshScrollViewDataSourceDidFinishedLoading:(UIScrollView *)scrollView {	
-	
-	[UIView beginAnimations:nil context:NULL];
-	[UIView setAnimationDuration:.3];
-	[scrollView setContentInset:UIEdgeInsetsMake(0.0f, 0.0f, 0.0f, 0.0f)];
-	[UIView commitAnimations];
-	
-	[self setState:EGOOPullRefreshNormal];
 
+#pragma mark - ScrollView Methods
+
+- (void)egoRefreshScrollViewDidScroll:(UIScrollView *)scrollView
+{
+    if (_state == EGOOPullRefreshLoading)
+    {
+        CGFloat offset = MAX(scrollView.contentOffset.y * -1, 0);
+        offset = MIN(offset, 60);
+        scrollView.contentInset = UIEdgeInsetsMake(offset, 0.0f, 0.0f, 0.0f);
+    }
+    else if (scrollView.isDragging)
+    {
+        BOOL _loading = NO;
+        if ([_delegate respondsToSelector:@selector(egoRefreshTableHeaderDataSourceIsLoading:)])
+        {
+            _loading = [_delegate egoRefreshTableHeaderDataSourceIsLoading:self];
+        }
+        
+        if (_state == EGOOPullRefreshPulling && scrollView.contentOffset.y > -65.0f &&
+            scrollView.contentOffset.y < 0.0f && !_loading)
+        {
+            [self setState:EGOOPullRefreshNormal];
+        }
+        else if (_state == EGOOPullRefreshNormal && scrollView.contentOffset.y < -65.0f && !_loading)
+        {
+            [self setState:EGOOPullRefreshPulling];
+        }
+        
+        if (scrollView.contentInset.top != 0)
+        {
+            scrollView.contentInset = UIEdgeInsetsZero;
+        }
+    }
+}
+
+- (void)egoRefreshScrollViewDidEndDragging:(UIScrollView *)scrollView
+{
+    BOOL _loading = NO;
+    if ([_delegate respondsToSelector:@selector(egoRefreshTableHeaderDataSourceIsLoading:)])
+    {
+        _loading = [_delegate egoRefreshTableHeaderDataSourceIsLoading:self];
+    }
+    
+    if (scrollView.contentOffset.y <= - 65.0f && !_loading)
+    {
+        if ([_delegate respondsToSelector:@selector(egoRefreshTableHeaderDidTriggerRefresh:)])
+        {
+            [_delegate egoRefreshTableHeaderDidTriggerRefresh:self];
+        }
+        
+        [self setState:EGOOPullRefreshLoading];
+        [UIView beginAnimations:nil context:NULL];
+        [UIView setAnimationDuration:0.2];
+        scrollView.contentInset = UIEdgeInsetsMake(60.0f, 0.0f, 0.0f, 0.0f);
+        [UIView commitAnimations];
+    }
+    
+}
+
+- (void)egoRefreshScrollViewDataSourceDidFinishedLoading:(UIScrollView *)scrollView
+{
+    [UIView beginAnimations:nil context:NULL];
+    [UIView setAnimationDuration:.3];
+    [scrollView setContentInset:UIEdgeInsetsMake(0.0f, 0.0f, 0.0f, 0.0f)];
+    [UIView commitAnimations];
+    [self setState:EGOOPullRefreshNormal];
 }
 
 
-#pragma mark -
-#pragma mark Dealloc
+#pragma mark - Dealloc
 
-- (void)dealloc {
-	
-	_delegate=nil;
-	_activityView = nil;
-	_statusLabel = nil;
-	_arrowImage = nil;
-	_lastUpdatedLabel = nil;
+- (void)dealloc
+{
+    self.delegate = nil;
+    
+    [_activityView release];
+    [_arrowImage release];
+    [_lastUpdatedLabel release];
+    [_statusLabel release];
+    
     [super dealloc];
 }
-
 
 @end

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
@@ -40,6 +40,8 @@
 
 @implementation EGORefreshTableHeaderView
 
+@synthesize activityView=_activityView;
+@synthesize arrowImage=_arrowImage;
 @synthesize delegate=_delegate;
 @synthesize lastUpdatedLabel=_lastUpdatedLabel;
 @synthesize objectKey=_objectKey;
@@ -91,12 +93,12 @@
 #endif
         
         [[self layer] addSublayer:layer];
-        _arrowImage=layer;
+        self.arrowImage = layer;
         
         UIActivityIndicatorView *view = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
         view.frame = CGRectMake(25.0f, frame.size.height - 38.0f, 20.0f, 20.0f);
         [self addSubview:view];
-        _activityView = view;
+        self.activityView = view;
         [view release];
         
         [self setState:EGOOPullRefreshNormal];
@@ -271,6 +273,7 @@
 - (void)dealloc
 {
     self.delegate = nil;
+    self.arrowImage = nil;
     
     [_activityView release];
     [_arrowImage release];

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
@@ -27,7 +27,6 @@
 #import "EGORefreshTableHeaderView.h"
 
 
-#define TEXT_COLOR [UIColor colorWithRed:87.0/255.0 green:108.0/255.0 blue:137.0/255.0 alpha:1.0]
 #define FLIP_ANIMATION_DURATION 0.18f
 
 
@@ -46,21 +45,24 @@
 @synthesize lastUpdatedLabel=_lastUpdatedLabel;
 @synthesize objectKey=_objectKey;
 @synthesize statusLabel=_statusLabel;
+@synthesize style=_style;
 
-- (id)initWithFrame:(CGRect)frame arrowImageName:(NSString *)arrow textColor:(UIColor *)textColor
+- (id)initWithFrame:(CGRect)frame 
+     arrowImageName:(NSString *)arrow 
+          textColor:(UIColor *)textColor
+    backgroundColor:(UIColor *)backgroundColor
+      activityStyle:(UIActivityIndicatorViewStyle)activityStyle
 {
     if ((self = [super initWithFrame:frame]))
     {
         self.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-        self.backgroundColor = [UIColor colorWithRed:226.0/255.0 green:231.0/255.0 blue:237.0/255.0 alpha:1.0];
+        self.backgroundColor = backgroundColor;
         
-        UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(0.0f,frame.size.height - 30.0f,
+        UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(0.0f, frame.size.height - 30.0f,
                                                                    self.frame.size.width, 20.0f)];
         label.autoresizingMask = UIViewAutoresizingFlexibleWidth;
         label.font = [UIFont systemFontOfSize:12.0f];
         label.textColor = textColor;
-        label.shadowColor = [UIColor colorWithWhite:0.9f alpha:1.0f];
-        label.shadowOffset = CGSizeMake(0.0f, 1.0f);
         label.backgroundColor = [UIColor clearColor];
         label.textAlignment = UITextAlignmentCenter;
         [self addSubview:label];
@@ -72,8 +74,6 @@
         label.autoresizingMask = UIViewAutoresizingFlexibleWidth;
         label.font = [UIFont boldSystemFontOfSize:13.0f];
         label.textColor = textColor;
-        label.shadowColor = [UIColor colorWithWhite:0.9f alpha:1.0f];
-        label.shadowOffset = CGSizeMake(0.0f, 1.0f);
         label.backgroundColor = [UIColor clearColor];
         label.textAlignment = UITextAlignmentCenter;
         [self addSubview:label];
@@ -95,7 +95,7 @@
         [[self layer] addSublayer:layer];
         self.arrowImage = layer;
         
-        UIActivityIndicatorView *view = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+        UIActivityIndicatorView *view = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:activityStyle];
         view.frame = CGRectMake(25.0f, frame.size.height - 38.0f, 20.0f, 20.0f);
         [self addSubview:view];
         self.activityView = view;
@@ -108,14 +108,65 @@
 
 - (id)initWithFrame:(CGRect)frame
 {
-    return [self initWithFrame:frame arrowImageName:@"blueArrow.png" textColor:TEXT_COLOR];
+    return [self initWithFrame:frame style:EGOStyleBlue];
 }
 
-- (id)initWithView:(UIView *)view andTableView:(UITableView *)tableView
+- (id)initWithView:(UIView *)view tableView:(UITableView *)tableView
 {
     CGRect defaultFrame = CGRectMake(0.0f, 0.0f - tableView.bounds.size.height,
                                      view.frame.size.width, tableView.bounds.size.height);
     return [self initWithFrame:defaultFrame];
+}
+
+- (id)initWithView:(UIView *)view tableView:(UITableView *)tableView style:(EGOStyle)style
+{
+    CGRect defaultFrame = CGRectMake(0.0f, 0.0f - tableView.bounds.size.height,
+                                     view.frame.size.width, tableView.bounds.size.height);
+    return [self initWithFrame:defaultFrame style:style];
+}
+
+- (id)initWithFrame:(CGRect)frame style:(EGOStyle)style
+{
+    UIColor *textColor;
+    UIColor *backgroundColor;
+    NSString *arrowImageName;
+    UIActivityIndicatorViewStyle activityStyle;
+    
+    switch (style)
+    {
+        case EGOStyleBlack:
+            backgroundColor = [UIColor blackColor];
+            textColor = [UIColor whiteColor];
+            arrowImageName = @"whiteArrow.png";
+            activityStyle = UIActivityIndicatorViewStyleWhite;
+            break;
+            
+        case EGOStyleWhite:
+            backgroundColor = [UIColor whiteColor];
+            textColor = [UIColor blackColor];
+            arrowImageName = @"blackArrow.png";
+            activityStyle = UIActivityIndicatorViewStyleGray;
+            break;
+            
+        case EGOStyleGrey:
+            backgroundColor = [UIColor whiteColor];
+            textColor = [UIColor grayColor];
+            arrowImageName = @"grayArrow.png";
+            activityStyle = UIActivityIndicatorViewStyleGray;
+            break;
+            
+        default:
+            backgroundColor = [UIColor colorWithRed:226.0/255.0 green:231.0/255.0 blue:237.0/255.0 alpha:1.0];
+            textColor = [UIColor colorWithRed:87.0/255.0 green:108.0/255.0 blue:137.0/255.0 alpha:1.0];
+            arrowImageName = @"blueArrow.png";
+            activityStyle = UIActivityIndicatorViewStyleGray;
+    }
+    
+    return [self initWithFrame:frame 
+                arrowImageName:arrowImageName 
+                     textColor:textColor 
+               backgroundColor:backgroundColor 
+                 activityStyle:activityStyle];
 }
 
 

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
@@ -295,14 +295,14 @@
     {
         _loading = [_delegate egoRefreshTableHeaderDataSourceIsLoading:self];
     }
-    
+        
     if (scrollView.contentOffset.y <= - 65.0f && !_loading)
     {
         if ([_delegate respondsToSelector:@selector(egoRefreshTableHeaderDidTriggerRefresh:)])
         {
             [_delegate egoRefreshTableHeaderDidTriggerRefresh:self];
         }
-        
+                
         [self setState:EGOOPullRefreshLoading];
         [UIView beginAnimations:nil context:NULL];
         [UIView setAnimationDuration:0.2];
@@ -310,6 +310,11 @@
                                                    self.defaultInsets.left, 
                                                    self.defaultInsets.bottom, 
                                                    self.defaultInsets.right);
+        if ([_delegate respondsToSelector:@selector(animationDidStop:finished:)])
+        {
+            [UIView setAnimationDelegate:_delegate];
+            [UIView setAnimationDidStopSelector:@selector(animationDidStop:finished:)];
+        }
         [UIView commitAnimations];
     }
     

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
@@ -130,6 +130,8 @@
         [dateFormatter setDateStyle:NSDateFormatterShortStyle];
         [dateFormatter setTimeStyle:NSDateFormatterShortStyle];
         
+        NSString *label = NSLocalizedString(@"Last Updated", @"Last Updated label");
+        _lastUpdatedLabel.text = [NSString stringWithFormat:@"%@: %@", label, [dateFormatter stringFromDate:date]];
         _lastUpdatedLabel.text = [NSString stringWithFormat:@"Last Updated: %@", [dateFormatter stringFromDate:date]];
         
         NSString *forKey;

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
@@ -41,6 +41,7 @@
 
 @synthesize activityView=_activityView;
 @synthesize arrowImage=_arrowImage;
+@synthesize defaultInsets=_defaultInsets;
 @synthesize delegate=_delegate;
 @synthesize lastUpdatedLabel=_lastUpdatedLabel;
 @synthesize objectKey=_objectKey;
@@ -257,7 +258,10 @@
     {
         CGFloat offset = MAX(scrollView.contentOffset.y * -1, 0);
         offset = MIN(offset, 60);
-        scrollView.contentInset = UIEdgeInsetsMake(offset, 0.0f, 0.0f, 0.0f);
+        scrollView.contentInset = UIEdgeInsetsMake(offset,
+                                                   self.defaultInsets.left,
+                                                   self.defaultInsets.bottom,
+                                                   self.defaultInsets.right);
     }
     else if (scrollView.isDragging)
     {
@@ -302,7 +306,10 @@
         [self setState:EGOOPullRefreshLoading];
         [UIView beginAnimations:nil context:NULL];
         [UIView setAnimationDuration:0.2];
-        scrollView.contentInset = UIEdgeInsetsMake(60.0f, 0.0f, 0.0f, 0.0f);
+        scrollView.contentInset = UIEdgeInsetsMake(60.0f + self.defaultInsets.top, 
+                                                   self.defaultInsets.left, 
+                                                   self.defaultInsets.bottom, 
+                                                   self.defaultInsets.right);
         [UIView commitAnimations];
     }
     
@@ -312,7 +319,7 @@
 {
     [UIView beginAnimations:nil context:NULL];
     [UIView setAnimationDuration:.3];
-    [scrollView setContentInset:UIEdgeInsetsMake(0.0f, 0.0f, 0.0f, 0.0f)];
+    [scrollView setContentInset:self.defaultInsets];
     [UIView commitAnimations];
     [self setState:EGOOPullRefreshNormal];
 }

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
@@ -130,14 +130,14 @@
         [dateFormatter setDateStyle:NSDateFormatterShortStyle];
         [dateFormatter setTimeStyle:NSDateFormatterShortStyle];
         
-        NSString *label = NSLocalizedString(@"Last Updated", @"Last Updated label");
-        _lastUpdatedLabel.text = [NSString stringWithFormat:@"%@: %@", label, [dateFormatter stringFromDate:date]];
-        _lastUpdatedLabel.text = [NSString stringWithFormat:@"Last Updated: %@", [dateFormatter stringFromDate:date]];
+        NSString *lastUpdatedLabel = NSLocalizedString(@"Last Updated: ", @"Last Updated Label");
+        _lastUpdatedLabel.text = [NSString stringWithFormat:@"%@%@", lastUpdatedLabel, 
+                                  [dateFormatter stringFromDate:date]];
         
         NSString *forKey;
         if (self.objectKey)
         {
-            forKey = [forKey stringByAppendingFormat:@"EGORefreshTableView_LastRefresh_%@", self.objectKey];
+            forKey = [NSString stringWithFormat:@"EGORefreshTableView_LastRefresh_%@", self.objectKey];
         }
         else
         {

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
@@ -198,7 +198,6 @@
         }
         
         [[NSUserDefaults standardUserDefaults] setObject:_lastUpdatedLabel.text forKey:forKey];
-        [[NSUserDefaults standardUserDefaults] synchronize];
     }
     else
     {

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
@@ -281,9 +281,9 @@
             [self setState:EGOOPullRefreshPulling];
         }
         
-        if (scrollView.contentInset.top != 0)
+        if (scrollView.contentInset.top != self.defaultInsets.top)
         {
-            scrollView.contentInset = UIEdgeInsetsZero;
+            scrollView.contentInset = self.defaultInsets;
         }
     }
 }


### PR DESCRIPTION
I refactored the initializers and added the idea of having EGOStyle define a set of predefined styles. EGOStyleBlack for example initializes a PullRefresh with a black background, white arrow, and white text:

```
typedef enum {
    EGOStyleBlue,
    EGOStyleBlack,
    EGOStyleWhite,
    EGOStyleGrey,
} EGOStyle;
```

Also added some initializers that create the frame based on a table and view.

```
EGORefreshTableHeaderView *refreshView = [[EGORefreshTableHeaderView alloc] initWithView:self.view
                                                                               tableView:self.tableView
                                                                                   style:EGOStyleBlack];
```

Added an "objectKey" property that allows you to save different instances of the date to NSUserDefaults.

```
refreshView.objectKey = @"keyForThisInstance"
```

Finally, I exposed the properties publicly so those can be modified more readily:

```
@implementation RefreshTableHeaderView

- (id)initWithView:(UIView *)view tableView:(UITableView *)tableView style:(EGOStyle)style
{
  self = [super initWithView:view tableView:tableView style:style];
  if (self)
  {
      self.backgroundColor = [UIColor colorWithWhite:0.1f alpha:1.0f];
      self.statusLabel.textColor = [UIColor redColor];
      self.statusLabel.shadowColor = [UIColor colorWithWhite:0.0f alpha:0.75f];
      self.statusLabel.shadowOffset = CGSizeMake(0.0f, 1.0f);
      self.lastUpdatedLabel.textColor = [UIColor redColor];
      self.lastUpdatedLabel.shadowColor = [UIColor colorWithWhite:0.0f alpha:0.75f];
      self.lastUpdatedLabel.shadowOffset = CGSizeMake(0.0f, 1.0f);
  }
  return self;
}

@end
```

Also cleaned up formatting (tabs -> spaces, et al). Let me know if anything is broken.
