### PR TITLE
Fix small-loading time bug.

### DIFF
--- a/Demo/TableViewPull/Classes/Controller/RootViewController/RootViewController.m
+++ b/Demo/TableViewPull/Classes/Controller/RootViewController/RootViewController.m
@@ -119,6 +119,12 @@
 	
 }
 
+-(void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag {
+    if (!_reloading) {
+        [_refreshHeaderView egoRefreshScrollViewDataSourceDidFinishedLoading:self.tableView];
+    }
+}
+
 
 #pragma mark -
 #pragma mark EGORefreshTableHeaderDelegate Methods
@@ -126,7 +132,8 @@
 - (void)egoRefreshTableHeaderDidTriggerRefresh:(EGORefreshTableHeaderView*)view{
 	
 	[self reloadTableViewDataSource];
-	[self performSelector:@selector(doneLoadingTableViewData) withObject:nil afterDelay:3.0];
+    [self doneLoadingTableViewData];
+	//[self performSelector:@selector(doneLoadingTableViewData) withObject:nil afterDelay:3.0];
 	
 }
 

--- a/Demo/TableViewPull/Classes/View/RefreshTableHeaderView/EGORefreshTableHeaderView.m
+++ b/Demo/TableViewPull/Classes/View/RefreshTableHeaderView/EGORefreshTableHeaderView.m
@@ -225,6 +225,8 @@
 		[UIView beginAnimations:nil context:NULL];
 		[UIView setAnimationDuration:0.2];
 		scrollView.contentInset = UIEdgeInsetsMake(60.0f, 0.0f, 0.0f, 0.0f);
+        [UIView setAnimationDelegate:_delegate];
+        [UIView setAnimationDidStopSelector:@selector(animationDidStop:finished:)];
 		[UIView commitAnimations];
 		
 	}

--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
@@ -228,6 +228,8 @@
 		[UIView beginAnimations:nil context:NULL];
 		[UIView setAnimationDuration:0.2];
 		scrollView.contentInset = UIEdgeInsetsMake(60.0f, 0.0f, 0.0f, 0.0f);
+        [UIView setAnimationDelegate:_delegate];
+        [UIView setAnimationDidStopSelector:@selector(animationDidStop:finished:)];
 		[UIView commitAnimations];
 		
 	}


### PR DESCRIPTION
Added animation delegate to re-check if data is finished loading. This fixes a bug which causes the loading view to display indefinately if the data is loaded before the pull-down animation is complete.

There may well be a better way of doing this, but it demonstrates the problem. Demo files updated too.
