### PR TITLE
Add CocoaPods podspec

### DIFF
--- a/EGOTableViewPullRefresh.podspec
+++ b/EGOTableViewPullRefresh.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
                  :commit => '743679ffeb6ac02f0afffaac46f318dd2ce6122e' }
 
   s.source_files = 'EGOTableViewPullRefresh/Classes/View/*.{h,m}'
-  s.resources    = 'EGOTableViewPullRefresh/Resources'
+  s.resources    = 'EGOTableViewPullRefresh/Resources/*.png'
   s.clean_paths  = 'Demo'
   s.framework    = 'QuartzCore'
 end

--- a/EGOTableViewPullRefresh.podspec
+++ b/EGOTableViewPullRefresh.podspec
@@ -11,4 +11,5 @@ Pod::Spec.new do |s|
   s.source_files = 'EGOTableViewPullRefresh/Classes/View/*.{h,m}'
   s.resources    = 'EGOTableViewPullRefresh/Resources'
   s.clean_paths  = 'Demo'
+  s.framework    = 'QuartzCore'
 end

--- a/EGOTableViewPullRefresh.podspec
+++ b/EGOTableViewPullRefresh.podspec
@@ -1,6 +1,7 @@
 Pod::Spec.new do |s|
   s.name     = 'EGOTableViewPullRefresh'
   s.version  = '0.1.0'
+  s.platform = :ios
   s.license  = 'MIT'
   s.summary  = 'A similar control to the pull down to refresh control created by atebits in Tweetie 2.'
   s.homepage = 'https://github.com/enormego/EGOTableViewPullRefresh'

--- a/EGOTableViewPullRefresh.podspec
+++ b/EGOTableViewPullRefresh.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name     = 'EGOTableViewPullRefresh'
+  s.version  = '0.1.0'
+  s.license  = 'MIT'
+  s.summary  = 'A similar control to the pull down to refresh control created by atebits in Tweetie 2.'
+  s.homepage = 'https://github.com/enormego/EGOTableViewPullRefresh'
+  s.author   = { 'Devin Doty' => 'devin.r.doty@gmail.com' }
+  s.source   = { :git    => 'https://github.com/enormego/EGOTableViewPullRefresh.git',
+                 :commit => '743679ffeb6ac02f0afffaac46f318dd2ce6122e' }
+
+  s.source_files = 'EGOTableViewPullRefresh/Classes/View/*.{h,m}'
+  s.resources    = 'EGOTableViewPullRefresh/Resources'
+  s.clean_paths  = 'Demo'
+end


### PR DESCRIPTION
I recently added EGOTableViewPullRefresh to the [CocoaPods](https://github.com/CocoaPods/CocoaPods) package manager.

Since EGOTableViewPullRefresh doesn't currently have a discreet version, I treated [the current commit](https://github.com/CocoaPods/Specs/commit/5d6c079868d68d4259c26ebde049741d9c6dcdd2) as the 0.1 release. Would it be possible to have this commit tagged as 0.1 (or whatever version you feel comfortable with)? This will help greatly in dependency resolution.

Finally, this pull request adds the pod spec to the repo as well. Adding this will allow users to install an unreleased version directly from your repo. It also allows you to more easily keep the spec up-to-date with any possible changes, instead of having to remember it all when releasing a new version.

Thanks!
