### PR TITLE
Changed UITextAlignmetCenter into NSTextAlignmentCenter.

### DIFF
--- a/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
+++ b/EGOTableViewPullRefresh/Classes/View/EGORefreshTableHeaderView.m
@@ -53,7 +53,7 @@
 		label.shadowColor = [UIColor colorWithWhite:0.9f alpha:1.0f];
 		label.shadowOffset = CGSizeMake(0.0f, 1.0f);
 		label.backgroundColor = [UIColor clearColor];
-		label.textAlignment = UITextAlignmentCenter;
+		label.textAlignment = NSTextAlignmentCenter;
 		[self addSubview:label];
 		_lastUpdatedLabel=label;
 		[label release];
@@ -65,7 +65,7 @@
 		label.shadowColor = [UIColor colorWithWhite:0.9f alpha:1.0f];
 		label.shadowOffset = CGSizeMake(0.0f, 1.0f);
 		label.backgroundColor = [UIColor clearColor];
-		label.textAlignment = UITextAlignmentCenter;
+		label.textAlignment = NSTextAlignmentCenter;
 		[self addSubview:label];
 		_statusLabel=label;
 		[label release];


### PR DESCRIPTION
 UITextAlignmetCenter is deprecated in iOS 6
